### PR TITLE
fix: update Goerli references to Sepolia

### DIFF
--- a/examples/dids.md
+++ b/examples/dids.md
@@ -1,6 +1,6 @@
 Hover over these DIDs:
 
-- did:ethr:goerli:0x0277b9fca1dacfa732566e37aa6a67baee36ede6c67c6603c7cef062bbe27ab8e5
+- did:ethr:sepolia:0x02bd224258f3b0ae8fa5388342783d9697dac9133eb476c7946eeed9ac7b864ce1
 - did:web:community.veramo.io
 - did:key:z6Mko4bCnjYF9m1LZMtK9PtsXowyGGD8prU8CVNZSc9yupLB
 - did:pkh:eip155:1:0x5483FeB71AE2a5A889F75Be804461ba21C6D3E74


### PR DESCRIPTION
The project was using an outdated reference to the Goerli testnet, which has been deprecated with the Infura API. This commit updates the reference to the Sepolia testnet to ensure the network functionality is not interrupted.